### PR TITLE
deps: bump updatecli version to v0.109.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -38,7 +38,7 @@ body:
     description: |
       examples:
         - **OS**: Ubuntu 20.04
-        - **updatecli**: v0.50.1
+        - **updatecli**: v0.109.0
     value: |
         - OS:
         - updatecli:

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -38,7 +38,7 @@ body:
     description: |
       examples:
         - **OS**: Ubuntu 20.04
-        - **updatecli**: v0.95.1
+        - **updatecli**: v0.50.1
     value: |
         - OS:
         - updatecli:

--- a/README.adoc
+++ b/README.adoc
@@ -76,7 +76,7 @@ sha256sum --ignore-missing -c checksums.txt
 **Verify Container signature**
 
 ```
-cosign verify --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/updatecli/updatecli:v0.50.1
+cosign verify --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/updatecli/updatecli:v0.109.0
 ```
 
 == Documentation

--- a/README.adoc
+++ b/README.adoc
@@ -76,7 +76,7 @@ sha256sum --ignore-missing -c checksums.txt
 **Verify Container signature**
 
 ```
-cosign verify --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/updatecli/updatecli:v0.95.1
+cosign verify --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/updatecli/updatecli:v0.50.1
 ```
 
 == Documentation

--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ You can download/copy the three files 'checksums.txt.pem', 'checksums.txt.sig', 
 Once you have the three files locally, you can execute the following command
 
 ```
-cosign verify-blob --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --cert https://github.com/updatecli/updatecli/releases/download/v0.50.1/checksums.txt.pem --signature https://github.com/updatecli/updatecli/releases/download/v0.50.1/checksums.txt.sig checksums.txt
+cosign verify-blob --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --cert https://github.com/updatecli/updatecli/releases/download/v0.109.0/checksums.txt.pem --signature https://github.com/updatecli/updatecli/releases/download/v0.50.1/checksums.txt.sig checksums.txt
 ```
 
 A successful output looks like

--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ You can download/copy the three files 'checksums.txt.pem', 'checksums.txt.sig', 
 Once you have the three files locally, you can execute the following command
 
 ```
-cosign verify-blob --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --cert https://github.com/updatecli/updatecli/releases/download/v0.109.0/checksums.txt.pem --signature https://github.com/updatecli/updatecli/releases/download/v0.50.1/checksums.txt.sig checksums.txt
+cosign verify-blob --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --cert https://github.com/updatecli/updatecli/releases/download/v0.109.0/checksums.txt.pem --signature https://github.com/updatecli/updatecli/releases/download/v0.109.0/checksums.txt.sig checksums.txt
 ```
 
 A successful output looks like

--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ You can download/copy the three files 'checksums.txt.pem', 'checksums.txt.sig', 
 Once you have the three files locally, you can execute the following command
 
 ```
-cosign verify-blob --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --cert https://github.com/updatecli/updatecli/releases/download/v0.95.1/checksums.txt.pem --signature https://github.com/updatecli/updatecli/releases/download/v0.50.1/checksums.txt.sig checksums.txt
+cosign verify-blob --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --cert https://github.com/updatecli/updatecli/releases/download/v0.50.1/checksums.txt.pem --signature https://github.com/updatecli/updatecli/releases/download/v0.50.1/checksums.txt.sig checksums.txt
 ```
 
 A successful output looks like

--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ You can download/copy the three files 'checksums.txt.pem', 'checksums.txt.sig', 
 Once you have the three files locally, you can execute the following command
 
 ```
-cosign verify-blob --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --cert https://github.com/updatecli/updatecli/releases/download/v0.95.1/checksums.txt.pem --signature https://github.com/updatecli/updatecli/releases/download/v0.95.1/checksums.txt.sig checksums.txt
+cosign verify-blob --certificate-identity-regexp "https://github.com/updatecli/updatecli" --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --cert https://github.com/updatecli/updatecli/releases/download/v0.95.1/checksums.txt.pem --signature https://github.com/updatecli/updatecli/releases/download/v0.50.1/checksums.txt.sig checksums.txt
 ```
 
 A successful output looks like


### PR DESCRIPTION



<Actions>
    <action id="3536f642574044d89e8489ab688100dd8be6f79cdf6444386c25d7da02ab7756">
        <h3>docs: bump updatecli version</h3>
        <details id="082941241997a2e39db26afb58250ad2226817894a4cfee9e9da0973278d4547">
            <summary>docs: update updatecli version to v0.109.0</summary>
            <p>1 file(s) updated with &#34;**updatecli**: v0.109.0&#34;:&#xA;&#xA;* .github/ISSUE_TEMPLATE/1-bug-report.yml&#xA;</p>
            <details>
                <summary>v0.109.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;- Update ADOPTERS - SUSE Rancher and RKE2 @macedogm (#6250)&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat: allow NPM autodiscovery to ignore version constraint @olblak (#6360)&#xD;&#xA;- feat: add GitHub App support for authentication @olblak (#6155)&#xD;&#xA;- feat: add a slim Docker image for Updatecli @olblak (#5015)&#xD;&#xA;- fix: pause Updatecli when running out of GitHub API limit @olblak (#6168)&#xD;&#xA;- feat: Add build-dependencies support to cargo autodiscovery @refi64 (#6202)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/config to v1.31.13 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6389)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/credentials to v1.18.17 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6383)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2 to v1.39.3 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6381)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/config to v1.31.12 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6373)&#xD;&#xA;- deps(go): bump module github.com/aws/smithy-go to v1.23.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6361)&#xD;&#xA;- chore: dispatch release event @olblak (#6342)&#xD;&#xA;- deps(go): bump module github.com/spf13/afero to v1.15.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6343)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/service/ec2 to v1.256.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6348)&#xD;&#xA;- deps(go): bump module github.com/getsops/sops/v3 to v3.11.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6341)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/credentials to v1.18.16 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6332)&#xD;&#xA;- deps(go): bump module github.com/go-git/go-git/v5 to v5.16.3 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6321)&#xD;&#xA;- deps: Bump Golang version to 1.25.3 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6319)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/service/ec2 to v1.255.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6313)&#xD;&#xA;- deps(go): bump module cuelang.org/go to v0.14.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6296)&#xD;&#xA;- deps(go): bump module golang.org/x/oauth2 to v0.32.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6285)&#xD;&#xA;- deps(go): bump module golang.org/x/net to v0.46.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6267)&#xD;&#xA;- deps: Bump Golang version to 1.25.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6266)&#xD;&#xA;- deps(go): bump module github.com/fluxcd/helm-controller/api to v1.4.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6237)&#xD;&#xA;- deps(go): bump module github.com/fluxcd/source-controller/api to v1.7.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6203)&#xD;&#xA;- deps(go): bump module github.com/moby/buildkit to v0.25.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6214)&#xD;&#xA;- deps(go): bump module github.com/fluxcd/helm-controller/api to v1.4.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6193)&#xD;&#xA;- deps(go): bump module github.com/testcontainers/testcontainers-go to v0.39.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6175)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/service/ec2 to v1.254.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6179)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2 to v1.39.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6177)&#xD;&#xA;- deps: bump golangci-lint to v2.5.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6161)&#xD;&#xA;- deps(go): bump module github.com/moby/buildkit to v0.25.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6160)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@macedogm, @olblak, @refi64, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.50.1</summary>
                <pre>To improve report generated by Updatecli, this release introduces several major refactoring around source, condition, target.&#xD;&#xA;While this release do not introduce new feature, it has a higher risk of potential regression.&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- Fix yaml plugin regression @olblak (#1338)&#xD;&#xA;- Correctly handled target execution result @olblak (#1337)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
        </details>
        <details id="1a458326beeb2ca53bc8da71dc71faa729f078dc9f4b2507368299e5dd57193a">
            <summary>docs: update issue template with Updatecli version to v0.109.0</summary>
            <p>1 file(s) updated with &#34;ghcr.io/updatecli/updatecli:v0.109.0&#34;:&#xA;&#xA;* README.adoc&#xA;</p>
            <details>
                <summary>v0.100.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat(gitlab/mergerequest): configure additional fields during mr creation @alikhil (#5094)&#xD;&#xA;- feat(autodiscovery/cargo): switch cargo update to cargo-upgrade @loispostula (#4793)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps(github/action): bump all dependencies @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5102)&#xD;&#xA;- deps: bump golangci-lint to v2.1.6 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5080)&#xD;&#xA;- deps(go): bump module oras.land/oras-go/v2 to v2.6.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5078)&#xD;&#xA;- deps: Bump Golang version to 1.24.3 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5052)&#xD;&#xA;- deps(go): bump module dario.cat/mergo to v1.0.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5061)&#xD;&#xA;- deps(go): bump module golang.org/x/oauth2 to v0.30.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5045)&#xD;&#xA;- deps(go): bump module golang.org/x/net to v0.40.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5039)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@alikhil, @loispostula, @olblak, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.101.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;- test(report): switch to testing report Merge instead of FromString @mcwarman (#5216)&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat(bitbucket): support pull request updates @mcwarman (#5133)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix(reports): ensure latest title and description are used @mcwarman (#5189)&#xD;&#xA;- fix(dockerfile): typo in yaml specification @loispostula (#5137)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps(go): bump module cuelang.org/go to v0.13.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5280)&#xD;&#xA;- deps(go): bump module gitlab.com/gitlab-org/api/client-go to v0.129.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5271)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 to v3.18.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5261)&#xD;&#xA;- deps(github/action): bump all dependencies @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5258)&#xD;&#xA;- deps(go): bump module github.com/zclconf/go-cty to v1.16.3 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5249)&#xD;&#xA;- deps(go): bump module github.com/goccy/go-yaml to v1.18.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5239)&#xD;&#xA;- deps(go): bump module github.com/fluxcd/helm-controller/api to v1.3.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5217)&#xD;&#xA;- chore: remove Dependabot configuration @olblak (#5175)&#xD;&#xA;- deps(go): bump module github.com/google/go-containerregistry to v0.20.5 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5162)&#xD;&#xA;- deps(go): bump module github.com/yuin/goldmark to v1.7.12 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5147)&#xD;&#xA;- deps(go): bump module github.com/google/go-containerregistry to v0.20.4 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5138)&#xD;&#xA;&#xD;&#xA;## 📝 Documentation&#xD;&#xA;&#xD;&#xA;- docs: create jsonschema for bitbucket scm configuration @olblak (#5190)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@loispostula, @mcwarman, @olblak, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.102.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- Various feature additions for CUE @refi64 (#5352)&#xD;&#xA;- feat(bitbucket): add support for pull request description merging @mcwarman (#5350)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: fix default argocd autodiscovery action title @olblak (#5419)&#xD;&#xA;- fix(reports): update target description to output correctly in markdown @mcwarman (#5309)&#xD;&#xA;- fix: remove duplicate generate schema @qianlongzt (#5299)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps(go): bump module github.com/hashicorp/terraform-registry-address to v0.3.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5409)&#xD;&#xA;- deps(go): bump module cuelang.org/go to v0.13.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5400)&#xD;&#xA;- deps(go): bump module golang.org/x/net to v0.41.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5381)&#xD;&#xA;- deps(go): bump module github.com/fluxcd/source-controller/api to v1.6.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5380)&#xD;&#xA;- deps(go): bump module github.com/go-git/go-git/v5 to v5.16.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5373)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 to v3.18.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5362)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@mcwarman, @olblak, @qianlongzt, @refi64, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.103.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;### Partial manifest:&#xD;&#xA;&#xD;&#xA;Partials manifests are named, reusable fragments of an Updatecli manifest, typically used to define repeatable logic for:&#xD;&#xA;&#xD;&#xA;* Scms (e.g., Git repository details)&#xD;&#xA;* Sources (e.g., version checks)&#xD;&#xA;* Conditions&#xD;&#xA;* Targets&#xD;&#xA;&#xD;&#xA;These fragments are automatically available to pipelines within the same directory, helping keep your main manifests DRY (Don&#39;t Repeat Yourself) and maintainable.&#xD;&#xA;&#xD;&#xA;A partial file must have a filename that starts with an underscore (`_`). Updatecli never loads these as standalone manifest files.&#xD;&#xA;&#xD;&#xA;IMPORTANT: Partial files are concatenated into the main manifest during execution. If a `---` YAML document separator is present, the partial feature will be disabled, as the resulting content would be treated as multiple separate YAML documents.&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;### Semver Version Filter&#xD;&#xA;&#xD;&#xA;When an AND group has one constraint with a prerelease but more than one constraint then prereleases will be included. For  example, `&gt;1.0.0-beta.1 &lt; 2`. In the past this would not have included prereleases because each constraint needed to have a prerelease. Now, only one constraint needs to have a prerelease. Note, this does not carry across OR groups. For example, `&gt;1.0.0-beta.1 &lt; 2 || &gt; 3`. In this case, prereleases will not be included when evaluating against `&gt;3`&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat: add partial manifest @olblak (#5508)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: Branch reset causes initial Github API commit to be lost  @MattiasAng (#5486)&#xD;&#xA;- fix(bitbucket): use body parameter on pull request updates @mcwarman (#5457)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- refactor(autodiscovery): unify discovery spec &amp; reduce boilerplate code &amp; fix `terragrunt` missing in jsonschema @qianlongzt &#xD;&#xA;- deps(go): bump module github.com/Masterminds/semver/v3 to v3.4.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5507)&#xD;&#xA;- deps(go): bump module sigs.k8s.io/yaml to v1.5.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5485)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 to v3.18.3 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5460)&#xD;&#xA;- deps(go): bump module cuelang.org/go to v0.13.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5464)&#xD;&#xA;&#xD;&#xA;## 📝 Documentation&#xD;&#xA;&#xD;&#xA;- doc: reformat code comment to improve website visualization @olblak (#5436)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@MattiasAng, @mcwarman, @olblak, @qianlongzt, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.103.1</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: panic when Updatecli manifests doesn&#39;t exist @olblak (#5543)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@olblak, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.104.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat: Allow to customize temporary working branch created by Updatecli @olblak (#5589)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: avoid loading partial when not needed @olblak (#5618)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps: bump golangci-lint to v2.2.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5619)&#xD;&#xA;- deps(go): bump module golang.org/x/net to v0.42.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5617)&#xD;&#xA;- deps(go): bump module golang.org/x/mod to v0.26.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5593)&#xD;&#xA;- deps(go): bump module golang.org/x/text to v0.27.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5600)&#xD;&#xA;- deps: Bump Golang version to 1.24.5 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5579)&#xD;&#xA;- deps(go): bump module github.com/fluxcd/source-controller/api to v1.6.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5588)&#xD;&#xA;- deps: bump golangci-lint to v2.2.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5570)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 to v3.18.4 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5556)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@olblak, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.105.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat: support multiple yaml keys for 1 target @pkazi (#5696)&#xD;&#xA;- feat: add Dasel v2 support for the JSON plugin @olblak (#5757)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix(actions) ensure HTML of change requests is valid (missing closingtag for `img`) @dduportal (#5743)&#xD;&#xA;- fix: remove linux/aarch64 from temurin e2e test @olblak (#5698)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps(github/action): bump all dependencies @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5792)&#xD;&#xA;- deps: bump buildkit &amp;&amp; sops version @olblak (#5789)&#xD;&#xA;- deps(go): bump module sigs.k8s.io/yaml to v1.6.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5782)&#xD;&#xA;- deps(go): bump module github.com/drone/go-scm to v1.40.3 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5780)&#xD;&#xA;- deps(go): bump module github.com/tomwright/dasel/v2 to v2.8.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5769)&#xD;&#xA;- chore(deps): bump github.com/docker/docker from 28.2.2+incompatible to 28.3.3+incompatible @[dependabot[bot]](https://github.com/apps/dependabot) (#5752)&#xD;&#xA;- deps(go): bump module github.com/yuin/goldmark to v1.7.13 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5734)&#xD;&#xA;- deps(github/action): bump all dependencies @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5728)&#xD;&#xA;- deps: bump golangci-lint to v2.3.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5697)&#xD;&#xA;- deps(updatecli/policies): bump all policies @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5707)&#xD;&#xA;- deps(github/action): bump all dependencies @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5676)&#xD;&#xA;- deps(go): bump module github.com/drone/go-scm to v1.40.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5666)&#xD;&#xA;- deps(go): bump module github.com/testcontainers/testcontainers-go to v0.38.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5665)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dduportal, @dependabot[bot], @olblak, @pkazi, @updateclibot[bot], [dependabot[bot]](https://github.com/apps/dependabot) and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.105.1</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: correct decoding logic for GitLab clientSpec to allow overwriting @hebestreit (#5811)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps: Bump Golang version to 1.24.6 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5839)&#xD;&#xA;- deps(github/action): bump all dependencies @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5843)&#xD;&#xA;- deps(github/action): bump all dependencies @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5838)&#xD;&#xA;- deps(go): bump module golang.org/x/net to v0.43.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5832)&#xD;&#xA;- deps(go): bump module golang.org/x/mod to v0.27.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5823)&#xD;&#xA;- chore: replace archived go module github.com/mitchellh/mapstructure @olblak (#5817)&#xD;&#xA;- deps: bump golangci-lint to v2.3.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5812)&#xD;&#xA;- deps(go): bump module cuelang.org/go to v0.14.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5798)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@hebestreit, @olblak, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.106.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat: add mermaidjs graph to report and remove experimental requirement @olblak (#5922)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix(yaml): correctly remove file protocol from file path @olblak (#5921)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps(github/action): bump all dependencies @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5941)&#xD;&#xA;- deps(go): bump module github.com/stretchr/testify to v1.11.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5937)&#xD;&#xA;- deps(go): bump module github.com/hashicorp/terraform-registry-address to v0.4.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5919)&#xD;&#xA;- deps(go): bump module github.com/stretchr/testify to v1.11.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5910)&#xD;&#xA;- deps(go): bump module github.com/beevik/etree to v1.6.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5907)&#xD;&#xA;- deps(go): bump module github.com/zclconf/go-cty to v1.16.4 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5903)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 to v3.18.6 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5897)&#xD;&#xA;- deps: Bump Golang version to 1.25.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5890)&#xD;&#xA;- deps(updatecli/policies): bump all policies @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5889)&#xD;&#xA;- deps: bump golangci-lint to v2.4.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5884)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 to v3.18.5 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5879)&#xD;&#xA;- deps(go): bump module github.com/drone/go-scm to v1.40.6 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5872)&#xD;&#xA;- deps(go): bump module github.com/drone/go-scm to v1.40.5 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5859)&#xD;&#xA;- deps(go): bump module cuelang.org/go to v0.14.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5851)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@olblak, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.107.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;- chore: test project telemetry using Scarf.io @olblak (#5972)&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat: Allow to use regex in Golang module matchingRule @olblak (#5986)&#xD;&#xA;- feat(file,golang): improve changelog generation with capture groups @ryancurrah (#5987)&#xD;&#xA;- feat(golang): support replace instruction in Go mod file  @olblak (#5963)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: helm changelog capitalize function @olblak (#5955)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps(go): bump module github.com/spf13/cobra to v1.10.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5988)&#xD;&#xA;- deps(github/action): bump all dependencies @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5995)&#xD;&#xA;- deps: Bump Golang version to 1.25.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5964)&#xD;&#xA;- deps(go): bump module github.com/moby/buildkit to v0.24.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5962)&#xD;&#xA;- deps(github/action): bump all dependencies @[updateclibot[bot]](https://github.com/apps/updateclibot) (#5952)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@olblak, @ryancurrah, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.108.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- Add assignee field support to Gitea Pull Request Action to achieve parity with GitHub implementation @localleon (#6084)&#xD;&#xA;- feat: allow to squash commit @olblak (#6032)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix(shell): handle empty environment value @olblak (#6024)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/config to v1.31.10 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6143)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/config to v1.29.18 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6139)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/credentials to v1.17.71 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6132)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/service/ec2 to v1.254.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6123)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2 to v1.39.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6114)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/service/ec2 to v1.251.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6101)&#xD;&#xA;- chore(deps): update aws-sdk-go library to v2 @olblak (#6021)&#xD;&#xA;- deps(go): bump module github.com/fluxcd/source-controller/api to v1.7.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6070)&#xD;&#xA;- deps(go): bump module golang.org/x/oauth2 to v0.31.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6059)&#xD;&#xA;- deps(go): bump module github.com/muesli/mango-cobra to v1.3.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6054)&#xD;&#xA;- deps(go): bump module golang.org/x/mod to v0.28.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6045)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 to v3.19.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6041)&#xD;&#xA;- deps(go): bump module golang.org/x/net to v0.44.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6028)&#xD;&#xA;- deps(go): bump module github.com/zclconf/go-cty to v1.17.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6010)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@localleon, @olblak, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.109.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;- Update ADOPTERS - SUSE Rancher and RKE2 @macedogm (#6250)&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat: allow NPM autodiscovery to ignore version constraint @olblak (#6360)&#xD;&#xA;- feat: add GitHub App support for authentication @olblak (#6155)&#xD;&#xA;- feat: add a slim Docker image for Updatecli @olblak (#5015)&#xD;&#xA;- fix: pause Updatecli when running out of GitHub API limit @olblak (#6168)&#xD;&#xA;- feat: Add build-dependencies support to cargo autodiscovery @refi64 (#6202)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/config to v1.31.13 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6389)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/credentials to v1.18.17 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6383)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2 to v1.39.3 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6381)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/config to v1.31.12 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6373)&#xD;&#xA;- deps(go): bump module github.com/aws/smithy-go to v1.23.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6361)&#xD;&#xA;- chore: dispatch release event @olblak (#6342)&#xD;&#xA;- deps(go): bump module github.com/spf13/afero to v1.15.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6343)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/service/ec2 to v1.256.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6348)&#xD;&#xA;- deps(go): bump module github.com/getsops/sops/v3 to v3.11.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6341)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/credentials to v1.18.16 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6332)&#xD;&#xA;- deps(go): bump module github.com/go-git/go-git/v5 to v5.16.3 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6321)&#xD;&#xA;- deps: Bump Golang version to 1.25.3 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6319)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/service/ec2 to v1.255.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6313)&#xD;&#xA;- deps(go): bump module cuelang.org/go to v0.14.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6296)&#xD;&#xA;- deps(go): bump module golang.org/x/oauth2 to v0.32.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6285)&#xD;&#xA;- deps(go): bump module golang.org/x/net to v0.46.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6267)&#xD;&#xA;- deps: Bump Golang version to 1.25.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6266)&#xD;&#xA;- deps(go): bump module github.com/fluxcd/helm-controller/api to v1.4.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6237)&#xD;&#xA;- deps(go): bump module github.com/fluxcd/source-controller/api to v1.7.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6203)&#xD;&#xA;- deps(go): bump module github.com/moby/buildkit to v0.25.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6214)&#xD;&#xA;- deps(go): bump module github.com/fluxcd/helm-controller/api to v1.4.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6193)&#xD;&#xA;- deps(go): bump module github.com/testcontainers/testcontainers-go to v0.39.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6175)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/service/ec2 to v1.254.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6179)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2 to v1.39.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6177)&#xD;&#xA;- deps: bump golangci-lint to v2.5.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6161)&#xD;&#xA;- deps(go): bump module github.com/moby/buildkit to v0.25.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#6160)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@macedogm, @olblak, @refi64, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.50.1</summary>
                <pre>To improve report generated by Updatecli, this release introduces several major refactoring around source, condition, target.&#xD;&#xA;While this release do not introduce new feature, it has a higher risk of potential regression.&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- Fix yaml plugin regression @olblak (#1338)&#xD;&#xA;- Correctly handled target execution result @olblak (#1337)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.51.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;This release introduces a refactoring for the YAML plugin to move away from a &#34;homemade&#34; like &#34;yamlpath&#34; to the library goccy/go-yaml which support more &#34;yamlpath&#34; query.&#xD;&#xA;&#xD;&#xA;Yamlpath keys are expected to start with &#39;$.&#39;, so for now we&#39;ll display a warning message when Updatecli detects the deprecated syntax and automatically add the prefix &#34;$.&#34;&#xD;&#xA;&#xD;&#xA;Manifests still need to be updated with the new syntax to remove the warning.&#xD;&#xA;&#xD;&#xA;Another important syntax change, dots could be escaped using a backslack such as `annotation.github\.owner`, now keys containing dot should be surrounded with single quote like `annotation.&#39;github.owner&#39;`&#xD;&#xA;&#xD;&#xA;Updatecli manifest using the YAML key must be updated such as  &#xD;&#xA;&#xD;&#xA;```&#xD;&#xA;`name` becomes `$.name`&#xD;&#xA;`array[0].name` becomes `$.array[0].name`&#xD;&#xA;`person\.name` becomes `&#39;person.name&#39;`&#xD;&#xA;```&#xD;&#xA;&#xD;&#xA;While this library better handle YAML formatting, we noticed a few drawback when Updatecli updates a target.&#xD;&#xA;&#xD;&#xA;* `key: &#34;value&#34;` would become `key: value`&#xD;&#xA;* `key:` would become `key: null`&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- YAML plugin supports YAMLPath @olblak (#1333)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- Bump Patch version for Golang module @updateclibot (#1328)&#xD;&#xA;- Use updatecli@main config as a fallback @jsoref (#1342)&#xD;&#xA;- Add check-spelling @jsoref (#1340)&#xD;&#xA;- chore(deps): Bump updatecli/updatecli-action from 2.28.2 to 2.29.0 @dependabot (#1341)&#xD;&#xA;- fix spelling @jsoref (#1330)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dependabot, @dependabot[bot], @jsoref, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.52.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- #1346: Implement the support for registry in the autodiscovery feature for helm @mavimo (#1347)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@mavimo, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.53.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;- Allow Maven autodiscovery to override default version filter @olblak (#1376)&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- Add versionfilter to maven resource @olblak (#1375)&#xD;&#xA;- Allow Docker Compose autodiscovery to override default version filter @olblak (#1366)&#xD;&#xA;- reset tagfilter when helm autodiscovery rely on versionfilter @olblak (#1369)&#xD;&#xA;- Allow to override dockerfile autodiscovery versionfilter @olblak (#1367)&#xD;&#xA;- Allow Rust Cargo autodiscovery to override default version filter @olblak (#1365)&#xD;&#xA;-  Allow NPM autodiscovery to override default version filter @olblak (#1360)&#xD;&#xA;- Allow Fleet autodiscovery to override default version filter @olblak (#1361)&#xD;&#xA;- Allow Helm autodiscovery to override default version filter @olblak (#1358)&#xD;&#xA;- Add Autodiscovery versionFilter for &#34;minoronly&#34; and &#34;majoronly&#34; semver update @olblak (#1357)&#xD;&#xA;- Allow Helmfile autodiscovery to override default version filter @olblak (#1359)&#xD;&#xA;- Add SCM information to pipeline report @olblak (#1356)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- reset tagfilter when helm autodiscovery rely on versionfilter @olblak (#1369)&#xD;&#xA;- Fix dockerfile target result in case of success @olblak (#1368)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- [updatecli] Bump Golang version to 1.20.5 @updateclibot (#1362)&#xD;&#xA;- Bump Minor version for Golang module @updateclibot (#1343)&#xD;&#xA;- Bump Patch version for Golang module @updateclibot (#1348)&#xD;&#xA;- chore(deps): Bump updatecli/updatecli-action from 2.29.0 to 2.30.0 @dependabot (#1349)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dependabot, @dependabot[bot], @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.54.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- Allowing the support for missing keys in Toml @dcoraboeuf (#1377)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: reference must be defined once at the beginning @olblak (#1393)&#xD;&#xA;- [gitea][gitlab] git checkout must use `username` instead of `user` @olblak (#1386)&#xD;&#xA;- `User` used instead of `Username` for the Bitbucket Server authentication @dcoraboeuf (#1373)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- Bump Minor version of Golang module @updateclibot (#1388)&#xD;&#xA;- Bump Patch version of Golang module @updateclibot (#1389)&#xD;&#xA;- chore(deps): Bump updatecli/updatecli-action from 2.30.0 to 2.31.0 @dependabot (#1380)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dcoraboeuf, @dependabot, @dependabot[bot], @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.55.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;- Update cosigin instruction for verifying container signature @olblak (#1409)&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- add hcl resource plugin @mcwarman (#1424) &#xD;&#xA;- Add Updatecli integration with Udash Part 2 @olblak (#1418)&#xD;&#xA;- Add Updatecli integration with Udash Part 1@olblak (#1344)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- Fix condition report by using the correct variable @olblak (#1426)&#xD;&#xA;- fix(gittag) ensure `gittag` targets does not fail due to (unspecified) version filters @dduportal (#1407)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- Bump Patch version of Golang module @updateclibot (#1430)&#xD;&#xA;- Bump Patch version of Golang module @updateclibot (#1422)&#xD;&#xA;- chore(deps): Bump updatecli/updatecli-action from 2.32.0 to 2.33.0 @dependabot (#1413)&#xD;&#xA;- [updatecli] Bump Golang version to 1.20.6 @updateclibot (#1414)&#xD;&#xA;- chore(deps): Bump anchore/sbom-action from 0.14.2 to 0.14.3 @dependabot (#1390)&#xD;&#xA;- chore(deps): Bump updatecli/updatecli-action from 2.31.0 to 2.32.0 @dependabot (#1401)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dduportal, @dependabot, @dependabot[bot], @mcwarman, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.55.1</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- Fix Udash login flow with access_token @olblak (#1436)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.55.2</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- Fix udash login when config doesn&#39; exist yet @olblak (#1439)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- chore(deps): Bump updatecli/updatecli-action from 2.33.0 to 2.35.0 @dependabot (#1438)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dependabot, @dependabot[bot], @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.56.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- Add versionincrement setting to Helm autodiscovery @olblak (#1446)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- allow to merge multiple values/secret files @olblak (#1447)&#xD;&#xA;- fix(cmd): remove duplicated default value @olblak (#1448)&#xD;&#xA;- fix Windows --values is broken (#1415)&#xD;&#xA;- fix invalid argument error when you pass full path in --values (#1253 )&#xD;&#xA;- fix(helm): stop version increments reordering yaml @mcwarman (#1444)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- [updatecli] Bump Golang version to 1.20.7 @updateclibot (#1443)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@mcwarman, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.57.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 💥 Breaking&#xD;&#xA;&#xD;&#xA;- Add Docker Image Tag to Docker Image Digest @olblak (#1464)&#xD;&#xA;  ⚠️ The content of the source of kind `dockerdigest` are changed: `latest@sha256:xxxxxx` instead of `sha256:xxxxxx`. You can restore the previous behavior by setting `spec.hidetag` to `true` (documented in https://www.updatecli.io/docs/plugins/resource/docker_digest/#_parameters)&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- Allow Updatecli manifest/values to use JSON file @olblak (#1463)&#xD;&#xA;- Add `toYaml` go template function from helm @olblak (#1458)&#xD;&#xA;- Support multiple manifest into one single file @olblak (#1457)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: handle non-existing cargo packages @loispostula (#1460)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- [updatecli] Bump Golang version to 1.21.0 @updateclibot (#1455)&#xD;&#xA;- chore(deps): Bump updatecli/updatecli-action from 2.35.0 to 2.36.0 @dependabot (#1452)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dependabot, @dependabot[bot], @loispostula, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.58.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- Disable Helm autodiscovery version increment by default @olblak (#1526)&#xD;&#xA;- Set autodiscovery setting &#34;groupby&#34; to &#34;all&#34; by default @olblak (#1485)&#xD;&#xA;- Show file plugin target diff by default @olblak (#1473)&#xD;&#xA;- Use target name as commit title by default @olblak (#1474)&#xD;&#xA;- Show templating debug in `updatecli manifest show --debug` @olblak (#1470)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- Update Golang module helm.sh/helm/v3 @olblak (#1521)&#xD;&#xA;- Update Golang module github.com/aws/aws-sdk-go @olblak (#1522)&#xD;&#xA;- Update Golang module golang.org/x/mod @olblak (#1519)&#xD;&#xA;- Update Golang module golang.org/x/oauth2 @olblak (#1514)&#xD;&#xA;- Update Golang module golang.org/x/text @olblak (#1516)&#xD;&#xA;- Update Golang module github.com/drone/go-scm @olblak (#1508)&#xD;&#xA;- Update Golang module github.com/go-git/go-git/v5 @olblak (#1512)&#xD;&#xA;- chore(deps): Bump updatecli/updatecli-action from 2.36.0 to 2.37.0 @dependabot (#1469)&#xD;&#xA;&#xD;&#xA;## 📝 Documentation&#xD;&#xA;&#xD;&#xA;- Improve scm comments @olblak (#1476)&#xD;&#xA;- Refactor helm documentation @olblak (#1467)&#xD;&#xA;- Refactor XML code comment used for jsonschema @olblak (#1466)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dependabot, @dependabot[bot], @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.59.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;- Add PITS Global Data Recovery Services as an adopter @benjx1990 (#1564)&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- Move jsonschema test from patternProperties to additionalProperties @olblak (#1570)&#xD;&#xA;- feat: add terraform resources @mcwarman (#1554)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: HelmChart always bumps Chart Version @olblak (#1541)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- [updatecli] Bump Golang version to 1.21.1 @updateclibot (#1568)&#xD;&#xA;- Update Golang module golang.org/x/oauth2 @updateclibot (#1567)&#xD;&#xA;- chore(deps): Bump actions/checkout from 3 to 4 @dependabot (#1566)&#xD;&#xA;- Update Golang module github.com/drone/go-scm @updateclibot (#1553)&#xD;&#xA;- Update Golang module github.com/hashicorp/hcl/v2 @updateclibot (#1558)&#xD;&#xA;- Update Golang module github.com/zclconf/go-cty @updateclibot (#1559)&#xD;&#xA;- Update Golang module golang.org/x/text @updateclibot (#1557)&#xD;&#xA;- Update Golang module github.com/heimdalr/dag @updateclibot (#1527)&#xD;&#xA;- Update Golang module github.com/drone/go-scm @updateclibot (#1543)&#xD;&#xA;- Update Golang module github.com/aws/aws-sdk-go @updateclibot (#1545)&#xD;&#xA;- chore(deps): Bump updatecli/updatecli-action from 2.37.0 to 2.38.0 @dependabot (#1536)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@benjx1990, @dependabot, @dependabot[bot], @mcwarman, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.60.0</summary>
                <pre>## WARNING&#xD;&#xA;&#xD;&#xA;This release contains a fix for the docker image plugin which correctly handles multi-architecture now.&#xD;&#xA;The side effect of this is that older docker images using the old manifest v1 which do not contain multi-architecture information&#xD;&#xA; will now fail if the setting `architecture` or `architectures` is explicitly set to amd64.&#xD;&#xA;&#xD;&#xA;If this happens you can just remove that Updatecli setting as it will be amd64 anyway&#xD;&#xA;&#xD;&#xA;&lt;details&gt;&lt;summary&gt;from&lt;/summary&gt;&#xD;&#xA;&#xD;&#xA;```&#xD;&#xA;conditions:&#xD;&#xA;  default:&#xD;&#xA;    kind: dockerimage&#xD;&#xA;    spec:&#xD;&#xA;      image: ghcr.io/updatecli/example:0.60.0&#xD;&#xA;      architecture: amd64&#xD;&#xA;```&#xD;&#xA;&#xD;&#xA;&lt;/details&gt;&#xD;&#xA;&lt;details&gt;&lt;summary&gt;to&lt;/summary&gt;&#xD;&#xA;&#xD;&#xA;```&#xD;&#xA;conditions:&#xD;&#xA;  default:&#xD;&#xA;    kind: dockerimage&#xD;&#xA;    spec:&#xD;&#xA;      image: ghcr.io/updatecli/example:0.60.0&#xD;&#xA;      # comment until ghcr.io/updatecli/example:0.60.0 support the schema v2&#xD;&#xA;      # architecture: amd64&#xD;&#xA;```&#xD;&#xA;&#xD;&#xA;https://docs.docker.com/registry/spec/deprecated-schema-v1/&#xD;&#xA;&#xD;&#xA;&lt;/details&gt;&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;- Revert &#34;Disable Helm autodiscovery version increment by default&#34; @olblak (#1572)&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat(ci): add terraform registry source @mcwarman (#1576)&#xD;&#xA;- Show version in Golang autodiscovery target name @olblak (#1574)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- Correctly set json resource result @olblak (#1592)&#xD;&#xA;- fix: ensure docker image checks architecture @mcwarman (#1589)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- Update Golang module github.com/goccy/go-yaml @updateclibot (#1597)&#xD;&#xA;- chore(deps): Bump goreleaser/goreleaser-action from 4 to 5 @dependabot (#1585)&#xD;&#xA;- Update Golang module github.com/goccy/go-yaml @updateclibot (#1595)&#xD;&#xA;- chore(deps): Bump docker/login-action from 2 to 3 @dependabot (#1586)&#xD;&#xA;- chore(deps): Bump docker/setup-buildx-action from 2 to 3 @dependabot (#1587)&#xD;&#xA;- chore(deps): Bump docker/setup-qemu-action from 2 to 3 @dependabot (#1584)&#xD;&#xA;- Update Golang module github.com/go-git/go-git/v5 @updateclibot (#1591)&#xD;&#xA;- chore(deps): Bump sigstore/cosign-installer from 2.8.1 to 3.1.2 @dependabot (#1563)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dependabot, @dependabot[bot], @mcwarman, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.61.0</summary>
                <pre>## WARNING&#xD;&#xA;&#xD;&#xA;This release contains a fix for the docker image plugin which correctly handles multi-architecture now.&#xD;&#xA;The side effect of this is that older docker images using the old manifest v1 which do not contain multi-architecture information&#xD;&#xA; will now fail if the setting `architecture` or `architectures` is explicitly set to amd64.&#xD;&#xA;&#xD;&#xA;If this happens you can just remove that Updatecli setting as it will be amd64 anyway&#xD;&#xA;&#xD;&#xA;&lt;details&gt;&lt;summary&gt;from&lt;/summary&gt;&#xD;&#xA;&#xD;&#xA;```&#xD;&#xA;conditions:&#xD;&#xA;  default:&#xD;&#xA;    kind: dockerimage&#xD;&#xA;    spec:&#xD;&#xA;      image: ghcr.io/updatecli/example:0.60.0&#xD;&#xA;      architecture: amd64&#xD;&#xA;```&#xD;&#xA;&#xD;&#xA;&lt;/details&gt;&#xD;&#xA;&lt;details&gt;&lt;summary&gt;to&lt;/summary&gt;&#xD;&#xA;&#xD;&#xA;```&#xD;&#xA;conditions:&#xD;&#xA;  default:&#xD;&#xA;    kind: dockerimage&#xD;&#xA;    spec:&#xD;&#xA;      image: ghcr.io/updatecli/example:0.60.0&#xD;&#xA;      # comment until ghcr.io/updatecli/example:0.60.0 support the schema v2&#xD;&#xA;      # architecture: amd64&#xD;&#xA;```&#xD;&#xA;&#xD;&#xA;https://docs.docker.com/registry/spec/deprecated-schema-v1/&#xD;&#xA;&#xD;&#xA;&lt;/details&gt;&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat: dockerimage support for setting os and variant @mcwarman (#1604)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- chore(deps): Bump updatecli/updatecli-action from 2.39.0 to 2.40.0 @dependabot (#1601)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dependabot, @dependabot[bot], @mcwarman, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.61.1</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- Run helm chart metadata update only on a changed target @olblak (#1616)&#xD;&#xA;- fix: dockerimage correctly set auth if arch unspecified @olblak (#1615)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- Update Golang module github.com/minamijoyo/hcledit @updateclibot (#1610)&#xD;&#xA;- chore(deps): Bump updatecli/updatecli-action from 2.40.0 to 2.41.0 @dependabot (#1609)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dependabot, @dependabot[bot], @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.62.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat: add new `auto` versionincrement field for helmchart resource @aroberts87 (#1593)&#xD;&#xA;- feat: terraform autodiscovery @mcwarman (#1621)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: sort terraform autodiscovery manifest during test @olblak (#1629)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- chore(deps): Bump updatecli/updatecli-action from 2.41.0 to 2.42.0 @dependabot (#1620)&#xD;&#xA;- Update Golang module github.com/drone/go-scm @updateclibot (#1630)&#xD;&#xA;- Update Golang module helm.sh/helm/v3 @updateclibot (#1626)&#xD;&#xA;&#xD;&#xA;## 📝 Documentation&#xD;&#xA;&#xD;&#xA;- docs: update terraform autodiscovery documentation @mcwarman (#1627)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@aroberts87, @dependabot, @dependabot[bot], @mcwarman, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.63.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;This release introduces, as an experimental feature, the ability to share and reuse Updatecli policies using OCI registries like dockerhub, ghcr.io, etc.&#xD;&#xA;This feature is expected to evolve in the coming weeks as we start using it. &#xD;&#xA;Updatecli experimental contains the following new command &#xD;&#xA;&#xD;&#xA;* `updatecli manifest publish`: to push manifest(s) to an OCI registry&#xD;&#xA;* `updatecli manifest pull`: pull manifest(s) from an OCI registry&#xD;&#xA;&#xD;&#xA;A first iteration of the documentation is available on: &#xD;&#xA;&#xD;&#xA;=&gt; https://www.updatecli.io/docs/core/shareandreuse/&#xD;&#xA;&#xD;&#xA;An example of a repository containing a policy &#xD;&#xA;&#xD;&#xA;=&gt; [updatecli/policy-autodiscovery](https://github.com/updatecli/policy-autodiscovery/)&#xD;&#xA;&#xD;&#xA;Published on [ghcr.io/updatecli/policies/autodiscovery:0.0.1-alpha](https://github.com/updatecli/policy-autodiscovery/pkgs/container/policies%2Fautodiscovery)&#xD;&#xA;&#xD;&#xA;Existing commands have been updated as well when it makes sense such as `updatecli diff --experimental ghcr.io/updatecli/policies/autodiscovery:latest`&#xD;&#xA;&#xD;&#xA;For better usage of those policies, we also introduce the following &#34;compose&#34; command which can be defined, using a new file named `update-compose.yaml`&#xD;&#xA;&#xD;&#xA;* `updatecli compose diff`&#xD;&#xA;* `updatecli compose apply`&#xD;&#xA;* `updatecli compose show`&#xD;&#xA;&#xD;&#xA;Documentation is available on&#xD;&#xA;-&gt; https://www.updatecli.io/docs/core/compose/&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- Allow prerelease in autodiscovery versionfilter @olblak (#1677)&#xD;&#xA;- Add update compose command @olblak (#1643)&#xD;&#xA;- Allow to share/reuse Updatecli manifest using any OCI registry @olblak (#1605)&#xD;&#xA;- feat: add `skippackaging` option to helm target @aroberts87 (#1641)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: messages are not in correct order @kuisathaverat (#1648)&#xD;&#xA;- Update for the release job @cpanato (#1684)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- chore(deps): Bump golang.org/x/net from 0.15.0 to 0.17.0 @dependabot (#1682)&#xD;&#xA;- Bump patch version for Golang module @updateclibot (#1680)&#xD;&#xA;- [updatecli] Bump Golang version to 1.21.3 @updateclibot (#1651)&#xD;&#xA;- Update Golang module github.com/hashicorp/hcl/v2 @updateclibot (#1653)&#xD;&#xA;- Update Golang module golang.org/x/mod @updateclibot (#1650)&#xD;&#xA;- Update Golang module github.com/drone/go-scm @updateclibot (#1647)&#xD;&#xA;- chore(deps): Bump check-spelling/check-spelling from 0.0.21 to 0.0.22 @dependabot (#1640)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@aroberts87, @cpanato, @dependabot, @dependabot[bot], @kuisathaverat, @lemeurherve, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.64.0</summary>
                <pre>## WARNING&#xD;&#xA;&#xD;&#xA;`pipelineid` is now a required field.&#xD;&#xA;It doesn&#39;t break existing pipeline execution but it now triggers an error message in IDE using schema validation.&#xD;&#xA;More information on https://github.com/orgs/updatecli/discussions/1692 for the motivation&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;- tag pipelineid as required in jsonschema @olblak (#1696)&#xD;&#xA;- update readme for the verify checksum signatures @cpanato (#1686)&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- chore: By default autodiscovery actionid should use the pipeline name @olblak (#1693)&#xD;&#xA;- chore: remove time from generated markdown man pages @olblak (#1688)&#xD;&#xA;- chore: clean up Updatecli manifest @olblak (#1687)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: fallback to updatecli.yaml or updatecli.d if no manifest specified @olblak (#1695)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@cpanato, @olblak, @updateclibot, @updateclibot[bot] and @v1v&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.64.1</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;- chore: cleanup updatecli configuration @olblak (#1698)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- compose file should work without oci policies @olblak (#1705)&#xD;&#xA;- latest tag shouldn&#39;t return the oldest tag @olblak (#1705 )&#xD;&#xA;- used sanitize policy version for before push to ensure that v prefix are removed @olblak (#1705 )&#xD;&#xA;-  various path scenarios when publishing policies @olblak (#1705 )&#xD;&#xA;- fix: do not exit on empty arguments @kuisathaverat (#1707)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- Deprecate pipeline title setting in favor of pipeline name @olblak (#1704)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@kuisathaverat, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.65.0</summary>
                <pre>&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat: revert pipelineid requirement and use manifest names to determine branch instead of (generated) pipelineid @olblak (#1713)&#xD;&#xA;&#xD;&#xA;&gt; [!IMPORTANT]  &#xD;&#xA;&gt; Unless your manifests specify a `pipelineid` attribute, this version of `updatecli` will re-create new PRs for each none merged dependency with a new (auto-generated) branch name.&#xD;&#xA;&gt; But in the future, changing your manifest content won&#39;t duplicate PRs as the manifest name is now used.&#xD;&#xA;&#xD;&#xA;- feat: support for pinning docker digests by image config @olblak (#1712)&#xD;&#xA;- feat: add manifest push --overwrite flag @olblak (#1714)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: correctly load default Updatecli manifest @olblak (#1724)&#xD;&#xA;- fix: for multiple pipelines report failure to load @mcwarman (#1721)&#xD;&#xA;- fix: pipeline without target always returned Skipped @olblak (#1715)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps: bump patch version for Golang package defined in go.mod @updateclibot (#1703)&#xD;&#xA;&#xD;&#xA;## 📝 Documentation&#xD;&#xA;&#xD;&#xA;- Update README.adoc example @olblak (#1711)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@mcwarman, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.65.1</summary>
                <pre>More information available on #1728 about the why we reverted #1729&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;- Revert &#34;fix: pipeline without target always returned Skipped&#34; @olblak (#1729)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- chore(deps): Bump google.golang.org/grpc from 1.57.0 to 1.57.1 @dependabot (#1727)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dependabot, @dependabot[bot], @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.66.0</summary>
                <pre>## Important&#xD;&#xA;&#xD;&#xA;By default, Updatecli now shows a link to the CI job used to generate a pullrequest.&#xD;&#xA;A live example is available on [github.com/updatecli/website](https://github.com/updatecli/website/pull/1227)&#xD;&#xA;This new behavior can be disabled using `disablepipelineurl` set to true.&#xD;&#xA;&#xD;&#xA;for example, using the following snippet&#xD;&#xA;&#xD;&#xA;```&#xD;&#xA;actions:&#xD;&#xA;    default:&#xD;&#xA;        title: &#39;ci: bump Venom version to {{ source &#34;latestVersion&#34; }}&#39;&#xD;&#xA;        kind: github/pullrequest&#xD;&#xA;        disablepipelineurl: true&#xD;&#xA;        spec:&#xD;&#xA;            automerge: true&#xD;&#xA;            labels:&#xD;&#xA;                - chore&#xD;&#xA;                - skip-changelog&#xD;&#xA;        scmid: default&#xD;&#xA;```&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat(git): allow to decide if we want to fetch submodules or not @mavimo (#1758)&#xD;&#xA;- feat(autodiscovery/cargo): allow advanced ignore/only rule @olblak (#1757)&#xD;&#xA;- feat(file): Allows to use file pattern in the file/files key @olblak (#1738)&#xD;&#xA;- feat(autodiscovery/maven): allow advanced ignore/only rule @olblak (#1756)&#xD;&#xA;- feat(autodiscovery/fleet): allow advanced ignore/only rule @olblak (#1755)&#xD;&#xA;- feat(autodiscovery/helmfile): allow advanced ignore/only rule @olblak (#1754)&#xD;&#xA;- feat(autodiscovery/npm): allow advanced ignore/only rule @olblak (#1753)&#xD;&#xA;- feat(autodiscovery/helm) allow advanced ignore/only rule @olblak (#1752)&#xD;&#xA;- feat(autodiscovery/updatecli): Add updatecli compose autodiscovery @olblak (#1749)&#xD;&#xA;- feat(yaml): add advanced yamlpath support @olblak (#1741)&#xD;&#xA;- feat(action): show CI url in pullrequest body @olblak (#1737)&#xD;&#xA;- feat(dockerfile) support multiple files @dduportal (#1739)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix(autodiscovery/dockercompose): allow multiple ignore rule @olblak (#1751)&#xD;&#xA;- fix(autodiscovery/dockerfile): allow multiple ignore rule @olblak (#1750)&#xD;&#xA;- fix(autodiscovery): fix default autodiscovery action title @olblak (#1742)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps: bump patch version for Golang package defined in go.mod @updateclibot (#1745)&#xD;&#xA;- chore(deps): Bump sigstore/cosign-installer from 3.1.2 to 3.2.0 @dependabot (#1748)&#xD;&#xA;- deps: bump Golang version to 1.21.4 @updateclibot (#1746)&#xD;&#xA;- chore(deps): Bump github.com/docker/docker from 24.0.6+incompatible to 24.0.7+incompatible @dependabot (#1734)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dduportal, @dependabot, @dependabot[bot], @mavimo, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.66.0-rc1</summary>
                <pre>## Important&#xD;&#xA;&#xD;&#xA;By default, Updatecli now shows a link to the CI job used to generate a pullrequest.&#xD;&#xA;A live example is available on [github.com/updatecli/website](https://github.com/updatecli/website/pull/1227)&#xD;&#xA;This new behavior can be disabled using `disablepipelineurl` set to true.&#xD;&#xA;&#xD;&#xA;for example, using the following snippet&#xD;&#xA;&#xD;&#xA;```&#xD;&#xA;actions:&#xD;&#xA;    default:&#xD;&#xA;        title: &#39;ci: bump Venom version to {{ source &#34;latestVersion&#34; }}&#39;&#xD;&#xA;        kind: github/pullrequest&#xD;&#xA;        disablepipelineurl: true&#xD;&#xA;        spec:&#xD;&#xA;            automerge: true&#xD;&#xA;            labels:&#xD;&#xA;                - chore&#xD;&#xA;                - skip-changelog&#xD;&#xA;        scmid: default&#xD;&#xA;```&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat(autodiscovery/cargo): allow advanced ignore/only rule @olblak (#1757)&#xD;&#xA;- feat(file): Allows to use file pattern in the file/files key @olblak (#1738)&#xD;&#xA;- feat(autodiscovery/maven): allow advanced ignore/only rule @olblak (#1756)&#xD;&#xA;- feat(autodiscovery/fleet): allow advanced ignore/only rule @olblak (#1755)&#xD;&#xA;- feat(autodiscovery/helmfile): allow advanced ignore/only rule @olblak (#1754)&#xD;&#xA;- feat(autodiscovery/npm): allow advanced ignore/only rule @olblak (#1753)&#xD;&#xA;- feat(autodiscovery/helm) allow advanced ignore/only rule @olblak (#1752)&#xD;&#xA;- feat(autodiscovery/updatecli): Add updatecli compose autodiscovery @olblak (#1749)&#xD;&#xA;- feat(yaml): add advanced yamlpath support @olblak (#1741)&#xD;&#xA;- feat(action): show CI url in pullrequest body @olblak (#1737)&#xD;&#xA;- feat(dockerfile) support multiple files @dduportal (#1739)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix(autodiscovery/dockercompose): allow multiple ignore rule @olblak (#1751)&#xD;&#xA;- fix(autodiscovery/dockerfile): allow multiple ignore rule @olblak (#1750)&#xD;&#xA;- fix(autodiscovery): fix default autodiscovery action title @olblak (#1742)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps: bump patch version for Golang package defined in go.mod @updateclibot (#1745)&#xD;&#xA;- chore(deps): Bump sigstore/cosign-installer from 3.1.2 to 3.2.0 @dependabot (#1748)&#xD;&#xA;- deps: bump Golang version to 1.21.4 @updateclibot (#1746)&#xD;&#xA;- chore(deps): Bump github.com/docker/docker from 24.0.6+incompatible to 24.0.7+incompatible @dependabot (#1734)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dduportal, @dependabot, @dependabot[bot], @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.66.1</summary>
                <pre>## Important&#xD;&#xA;&#xD;&#xA;There is a change affecting the Helm autodiscovery plugin with `only`,`ignore` rule.&#xD;&#xA;More information on https://github.com/updatecli/updatecli/issues/1769&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix(file): ignore searchpattern not found when used with matchpattern @olblak (#1766)&#xD;&#xA;- fix(action): action fails if CI is not detected @olblak (#1764)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- chore: remove usage of io/ioutil package as deprecated since Go 1.16 @mavimo (#1761)&#xD;&#xA;- chore: remove helper package that is not used anymore @mavimo (#1762)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@mavimo, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.67.0</summary>
                <pre>## C...